### PR TITLE
feat: make header sticky in article pages

### DIFF
--- a/src/app/articles/[slug]/ArticleContent.tsx
+++ b/src/app/articles/[slug]/ArticleContent.tsx
@@ -35,10 +35,10 @@ const ArticleContent: NextPage<Props> = async ({ slug }: Props): Promise<React.R
 
       <div className="grid gap-8 md:grid-cols-[20%_60%] lg:gap-12">
         <ol className="p-2 md:p-4 ml-2 md:col-start-1">
-          <h2 className="text-gray-800 dark:text-slate-300 underline sticky top-16 max-[1010px]:hidden">
+          <h2 className="text-gray-800 dark:text-slate-300 underline sticky top-20 max-[1010px]:hidden">
             🖌️ Table of Contents
           </h2>
-          <h2 className="text-gray-800 dark:text-slate-300 underline sticky top-16 min-[1010px]:hidden">🖌️ TOC</h2>
+          <h2 className="text-gray-800 dark:text-slate-300 underline sticky top-20 min-[1010px]:hidden">🖌️ TOC</h2>
           <MarkdownContents content={data} isToc />
         </ol>
         <div className="col-start-2">

--- a/src/app/atoms/MarkdownContents.tsx
+++ b/src/app/atoms/MarkdownContents.tsx
@@ -68,7 +68,7 @@ const MarkdownContents: NextPage<Props> = async ({ content, isToc = false }: Pro
     <>
       {isToc && (
         <ReactMarkdown
-          className="md:prose-md dark:prose-invert col-start-1 sticky top-[88px]"
+          className="md:prose-md dark:prose-invert col-start-1 sticky top-[92px]"
           allowedElements={['h2']}
           components={components}
         >

--- a/src/app/atoms/MarkdownContents.tsx
+++ b/src/app/atoms/MarkdownContents.tsx
@@ -188,7 +188,7 @@ const MarkdownContents: NextPage<Props> = async ({ content, isToc = false }: Pro
                   <p>{quote}</p>
                   <cite className={citeStyle}>
                     出典：
-                    <a href={href}>{cite}</a>
+                    <a href={href} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300">{cite}</a>
                   </cite>
                 </blockquote>
               );

--- a/src/app/atoms/header.tsx
+++ b/src/app/atoms/header.tsx
@@ -21,7 +21,7 @@ const Header: NextPage = (): React.ReactElement | null => {
   }
 
   return (
-    <div className="top-0 navbar bg-gray-100 dark:bg-slate-900 z-50">
+    <div className="sticky top-0 navbar bg-gray-100 dark:bg-slate-900 z-50">
       <div className="navbar-start">
         <div className="dropdown">
           <div tabIndex={0} role="button" className="btn btn-ghost btn-circle ">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,7 +46,7 @@ body {
 }
 
 .markdown a {
-  @apply text-blue-600 font-semibold;
+  @apply text-blue-600 dark:text-blue-400 font-semibold;
 }
 
 .markdown strong a {


### PR DESCRIPTION
## Summary
- ヘッダーがスクロール時に常に表示されるように sticky スタイルを追加
- Table of Contents の位置を調整してヘッダーと重ならないように修正
- ダークモード時のハイパーリンクの視認性も改善済み

## Test plan
- [ ] 記事ページでスクロールしてヘッダーが固定表示されることを確認
- [ ] Table of Contents が適切な位置に配置されることを確認
- [ ] ライトモードとダークモードの両方で正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)